### PR TITLE
Update MitoGeneExtractor.cpp (v1.9.6 conflict merging unresolved error)

### DIFF
--- a/MitoGeneExtractor.cpp
+++ b/MitoGeneExtractor.cpp
@@ -1767,11 +1767,7 @@ int main(int argc, char **argv)
 
   if (global_verbosity >= 3)
   {
-<<<<<<< HEAD
-    cout << "PROGRESS: Finished reading input DNA sequences. Found this number of input DNA sequences: "
-=======
     cerr << "PROGRESS: Finished reading input DNA sequences. Found this number of input DNA sequences: "
->>>>>>> refactor-bugfix-v1.9.6
     << seqs_DNA_reads_target.GetTaxaNum()  << endl;
   }
 


### PR DESCRIPTION
Fix unresolved conflict merging that resulted in a make error when compiling:
```
**make MitoGeneExtractor-v1.9.6beta4**
g++ -O2 -std=c++11 -Wno-alloc-size-larger-than  -I . -I tclap-1.2.5/include  MitoGeneExtractor.cpp global-types-and-parameters_MitoGeneExtractor.cpp exonerate_wrapper_and_parser.cpp -o MitoGeneExtractor-v1.9.6
MitoGeneExtractor.cpp:1774:27: error: too many decimal points in number
 1774 | >>>>>>> refactor-bugfix-v1.9.6
      |                           ^~~~
MitoGeneExtractor.cpp: In function ‘int main(int, char**)’:
MitoGeneExtractor.cpp:1770:1: error: version control conflict marker in file
 1770 | <<<<<<< HEAD
      | ^~~~~~~
make: *** [makefile:21: MitoGeneExtractor-v1.9.6beta4] Error 1
```

Caused by the lines below (1770) in MitoGeneExtractor.cpp:
```
<<<<<<< HEAD
    cout << "PROGRESS: Finished reading input DNA sequences. Found this number of input DNA sequences: "
=======
    cerr << "PROGRESS: Finished reading input DNA sequences. Found this number of input DNA sequences: "
>>>>>>> refactor-bugfix-v1.9.6
    << seqs_DNA_reads_target.GetTaxaNum()  << endl;
```

Replacing the above with the following:
```
    cerr << "PROGRESS: Finished reading input DNA sequences. Found this number of input DNA sequences: "
    << seqs_DNA_reads_target.GetTaxaNum()  << endl;
```

And rerunning the make command resulted in succesful compilation.